### PR TITLE
Build fix.

### DIFF
--- a/Sources/Activation.swift
+++ b/Sources/Activation.swift
@@ -302,7 +302,8 @@ public extension NeuralNet {
                     // TODO
                     break
                 case .sigmoid:
-                    result = zip(real, target).map{(-$0 * (1 - $0) * ($1 - $0))}
+                    let pairs = zip(real, target)
+                    result = pairs.map{(-$0 * (1 - $0) * ($1 - $0))}
                 case .softmax:
                     vDSP_vsub(target, 1,
                               real, 1,


### PR DESCRIPTION
Slightly changed the way sigmoid activation function is being calculated due to unability to compile the code the old way. It is probably bug in compiler in newer versions of Swift, but this simple solution enables compile again.